### PR TITLE
Add tests for list and dict parameter serialization

### DIFF
--- a/tests/unit/test_llm_fncall_converter.py
+++ b/tests/unit/test_llm_fncall_converter.py
@@ -682,6 +682,44 @@ def example():
 </parameter>
 </function>""",
         ),
+        # Test case with list parameter value
+        (
+            [
+                {
+                    'index': 1,
+                    'function': {
+                        'arguments': '{"command": "test", "path": "/test/file.py", "tags": ["tag1", "tag2", "tag with spaces"]}',
+                        'name': 'test_function',
+                    },
+                    'id': 'test_id',
+                    'type': 'function',
+                }
+            ],
+            """<function=test_function>
+<parameter=command>test</parameter>
+<parameter=path>/test/file.py</parameter>
+<parameter=tags>["tag1", "tag2", "tag with spaces"]</parameter>
+</function>""",
+        ),
+        # Test case with dict parameter value
+        (
+            [
+                {
+                    'index': 1,
+                    'function': {
+                        'arguments': '{"command": "test", "path": "/test/file.py", "metadata": {"key1": "value1", "key2": 42, "nested": {"subkey": "subvalue"}}}',
+                        'name': 'test_function',
+                    },
+                    'id': 'test_id',
+                    'type': 'function',
+                }
+            ],
+            """<function=test_function>
+<parameter=command>test</parameter>
+<parameter=path>/test/file.py</parameter>
+<parameter=metadata>{"key1": "value1", "key2": 42, "nested": {"subkey": "subvalue"}}</parameter>
+</function>""",
+        ),
     ],
 )
 def test_convert_tool_call_to_string(tool_calls, expected):


### PR DESCRIPTION
This PR adds tests for the conversion of list and dict parameter values in the `convert_tool_call_to_string` function.

I've added two new test cases:
- A test case with a list parameter value (`tags: ["tag1", "tag2", "tag with spaces"]`)
- A test case with a dict parameter value (`metadata: {"key1": "value1", "key2": 42, "nested": {"subkey": "subvalue"}}`)

These tests verify that the function correctly serializes list and dict parameter values using `json.dumps()`, which was the purpose of the original PR change.